### PR TITLE
Re-added tag removal for non-pjax requests

### DIFF
--- a/classes/response.php
+++ b/classes/response.php
@@ -17,11 +17,15 @@ class Response extends \Fuel\Core\Response
      */
     public function body($value = false)
     {
-        $is_pjax = (Input::server('HTTP_X_PJAX') OR Input::get('_pjax'));
-
+        $is_pjax = (Input::server('HTTP_X_PJAX') or Input::get('_pjax'));
+		
         if (func_num_args())
         {
-            $this->body = (!$is_pjax) ? $value : $this->filter_pjax($value);
+			Config::load('pjax');
+			$tag = Config::get('tag', '{# PJAX #}');
+			
+            $this->body = (!$is_pjax) ? str_replace($tag, '', $value) : $this->filter_pjax($value);
+			
             return $this;
         }
 


### PR DESCRIPTION
This version appears to be working properly. Now strips pjax tags when not receiving a pjax request again. 
